### PR TITLE
Remove stale getAllUnclaimedAuctions selector in swap upgrade

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,6 +33,16 @@ module.exports = {
   networks: {
     hardhat: {
       chainId: 8453,
+      // Base uses Cancun-era EVM rules. Hardhat needs a hardfork activation history for non-mainnet
+      // chainIds when executing against forked historical blocks.
+      hardfork: "cancun",
+      chains: {
+        8453: {
+          hardforkHistory: {
+            cancun: 0,
+          },
+        },
+      },
       forking: {
         url: process.env.BASE_RPC_URL,
       },

--- a/scripts/gbmBaazaar/upgrade-addSwapFns.ts
+++ b/scripts/gbmBaazaar/upgrade-addSwapFns.ts
@@ -38,6 +38,8 @@ export async function upgradeAddSwapFns() {
     "function getAuctionBidMultiplier(uint256) public view returns (uint64)",
     "function getBuyItNowInvalidationThreshold() external view returns (uint256)",
     "function isBiddingAllowed(address) public view returns (bool)",
+    // Removed from GBMFacet in this upgrade; ensure the selector is also removed from the diamond.
+    "function getAllUnclaimedAuctions() public view returns (uint256[])",
   ];
 
   const extendedFacetAdds: string[] = [

--- a/test/upgradeRemoveGetAllUnclaimedAuctionsSelector.ts
+++ b/test/upgradeRemoveGetAllUnclaimedAuctionsSelector.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { varsForNetwork } from "../helpers/constants";
+import { upgradeAddSwapFns } from "../scripts/gbmBaazaar/upgrade-addSwapFns";
+
+describe("Upgrade: remove getAllUnclaimedAuctions selector", function () {
+  it("removes getAllUnclaimedAuctions() from the diamond", async function () {
+    this.timeout(1_000_000);
+
+    const vars = await varsForNetwork(ethers as any);
+    const diamond = vars.gbmDiamond!;
+
+    const loupe = await ethers.getContractAt("DiamondLoupeFacet", diamond);
+    const selector = new ethers.utils.Interface([
+      "function getAllUnclaimedAuctions() view returns (uint256[])",
+    ]).getSighash("getAllUnclaimedAuctions()");
+
+    const before = await loupe.facetAddress(selector);
+    expect(
+      before,
+      "expected selector to exist pre-upgrade; base diamond may have changed"
+    ).to.not.eq(ethers.constants.AddressZero);
+
+    await upgradeAddSwapFns();
+
+    const after = await loupe.facetAddress(selector);
+    expect(after).to.eq(ethers.constants.AddressZero);
+  });
+});
+


### PR DESCRIPTION
Fixes a diamond-cut hygiene issue in PR #34: getAllUnclaimedAuctions() was removed from GBMFacet but the upgrade script did not remove its selector, so it could remain mapped to the old facet.

Changes:
- Add getAllUnclaimedAuctions() to gbmFacetRemovals in scripts/gbmBaazaar/upgrade-addSwapFns.ts.
- Add a fork test asserting the selector is removed after upgradeAddSwapFns().
- Hardhat Base-fork config: add chains[8453].hardforkHistory so forked calls can execute (required for tests).

Test:
- npx hardhat test test/upgradeRemoveGetAllUnclaimedAuctionsSelector.ts