### PR TITLE
Fix swap upgrade tests: revert strings

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,6 +33,16 @@ module.exports = {
   networks: {
     hardhat: {
       chainId: 8453,
+      // Base uses Cancun-era EVM rules. Hardhat needs a hardfork activation history for non-mainnet
+      // chainIds when executing against forked historical blocks.
+      hardfork: "cancun",
+      chains: {
+        8453: {
+          hardforkHistory: {
+            cancun: 0,
+          },
+        },
+      },
       forking: {
         url: process.env.BASE_RPC_URL,
       },

--- a/scripts/upgrades/upgrade-swapFns.ts
+++ b/scripts/upgrades/upgrade-swapFns.ts
@@ -31,10 +31,11 @@ describe("Upgrade: add swap functions and reallocate getters (base mainnet fork)
         tokenContract: ethers.constants.AddressZero,
         _tokenID: 0,
         _amount: 0,
-        _signature: "0x",
+        // Must be 65 bytes to avoid LibSignature "Invalid signature length"
+        _signature: "0x" + "00".repeat(65),
       };
       await expect(gbmFacet.swapAndCommitBid(ctx)).to.be.revertedWith(
-        "Invalid signature"
+        "bid: Invalid signature"
       );
     });
 
@@ -48,7 +49,7 @@ describe("Upgrade: add swap functions and reallocate getters (base mainnet fork)
         auctionID: 0,
       };
       await expect(gbmFacet.swapAndBuyNow(ctx)).to.be.revertedWith(
-        "deadline expired"
+        "LibTokenSwap: deadline expired"
       );
     });
   });


### PR DESCRIPTION
Fixes failing/incorrect assertions in scripts/upgrades/upgrade-swapFns.ts (PR #34):
- swapAndCommitBid invalid signature case must use a 65-byte signature and expect "bid: Invalid signature".
- swapAndBuyNow expired deadline expects "LibTokenSwap: deadline expired".

Also adds Base hardfork config (chains[8453].hardforkHistory) so forked calls can execute in Hardhat.

Test:
- npx hardhat test scripts/upgrades/upgrade-swapFns.ts