### PR TITLE
LibTokenSwap: enforce ERC20 transferFrom balance delta

### DIFF
--- a/contracts/test/MockZRouter.sol
+++ b/contracts/test/MockZRouter.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/IERC20.sol";
+
+/// @notice Minimal zRouter mock used for LibTokenSwap tests.
+/// @dev Treats `amountLimit` as the output amount to send to `to`.
+contract MockZRouter {
+    function swapAero(
+        address to,
+        bool /* stable */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function swapAeroCL(
+        address to,
+        bool /* exactOut */,
+        int24 /* tickSpacing */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function swapV2(
+        address to,
+        bool /* exactOut */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function _swap(address to, address tokenIn, address tokenOut, uint256 swapAmount, uint256 amountOut) private returns (uint256, uint256) {
+        if (tokenIn == address(0)) {
+            require(msg.value == swapAmount, "MockZRouter: bad msg.value");
+        } else {
+            IERC20(tokenIn).transferFrom(msg.sender, address(this), swapAmount);
+        }
+
+        IERC20(tokenOut).transfer(to, amountOut);
+        return (swapAmount, amountOut);
+    }
+}
+

--- a/contracts/test/ReturnTrueNoopERC20.sol
+++ b/contracts/test/ReturnTrueNoopERC20.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/IERC20.sol";
+
+/// @notice ERC20 that can be configured to return `true` from `transferFrom` without moving funds
+///         for a specific `from` address. Used to test LibTokenSwap balance-delta checks.
+contract ReturnTrueNoopERC20 is IERC20 {
+    string public name = "ReturnTrueNoopERC20";
+    string public symbol = "NOOP";
+    uint8 public decimals = 18;
+
+    uint256 public override totalSupply;
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) private _allowance;
+
+    address public noopFrom;
+
+    function setNoopFrom(address from) external {
+        noopFrom = from;
+    }
+
+    function allowance(address owner, address spender) external view override returns (uint256) {
+        return _allowance[owner][spender];
+    }
+
+    function approve(address spender, uint256 value) external override returns (bool) {
+        _allowance[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external override returns (bool) {
+        require(balanceOf[msg.sender] >= value, "NOOP: insufficient");
+        balanceOf[msg.sender] -= value;
+        balanceOf[to] += value;
+        emit Transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external override returns (bool) {
+        require(balanceOf[from] >= value, "NOOP: insufficient");
+
+        if (msg.sender != from) {
+            uint256 allowed = _allowance[from][msg.sender];
+            require(allowed >= value, "NOOP: allowance");
+            _allowance[from][msg.sender] = allowed - value;
+        }
+
+        if (from == noopFrom) {
+            // Claim success, but do not move funds.
+            emit Transfer(from, to, value);
+            return true;
+        }
+
+        balanceOf[from] -= value;
+        balanceOf[to] += value;
+        emit Transfer(from, to, value);
+        return true;
+    }
+
+    function mint(address to, uint256 value) external {
+        balanceOf[to] += value;
+        totalSupply += value;
+        emit Transfer(address(0), to, value);
+    }
+}
+

--- a/contracts/test/TokenSwapHarness.sol
+++ b/contracts/test/TokenSwapHarness.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../libraries/AppStorage.sol";
+import "../libraries/LibTokenSwap.sol";
+
+/// @notice Minimal harness to exercise LibTokenSwap in tests.
+/// @dev Stores AppStorage at slot 0 via Modifiers.s, matching LibTokenSwap.appStorage().
+contract TokenSwapHarness is Modifiers {
+    function setGHST(address ghst) external {
+        s.GHST = ghst;
+    }
+
+    function swapForGHST(address tokenIn, uint256 swapAmount, uint256 minGhstOut, uint256 deadline, address recipient) external payable returns (uint256) {
+        return LibTokenSwap.swapForGHST(tokenIn, swapAmount, minGhstOut, deadline, recipient);
+    }
+}
+

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,6 +33,16 @@ module.exports = {
   networks: {
     hardhat: {
       chainId: 8453,
+      // Base uses Cancun-era EVM rules. Hardhat needs a hardfork activation history for non-mainnet
+      // chainIds when executing against forked historical blocks.
+      hardfork: "cancun",
+      chains: {
+        8453: {
+          hardforkHistory: {
+            cancun: 0,
+          },
+        },
+      },
       forking: {
         url: process.env.BASE_RPC_URL,
       },

--- a/test/security/libTokenSwap.safeTransfer.ts
+++ b/test/security/libTokenSwap.safeTransfer.ts
@@ -1,0 +1,116 @@
+import { expect } from "chai";
+import { ethers, network } from "hardhat";
+
+const ROUTER = "0x0000000000404FECAf36E6184245475eE1254835";
+
+async function setCode(address: string, code: string) {
+  await network.provider.send("hardhat_setCode", [address, code]);
+}
+
+async function chainNowTs(): Promise<number> {
+  const block = await ethers.provider.getBlock("latest");
+  return block.timestamp;
+}
+
+describe("LibTokenSwap: safe ERC20 handling", function () {
+  it("reverts if transferFrom returns true but doesn't actually move tokens (prevents draining contract-held balance)", async function () {
+    this.timeout(120000);
+
+    const [user] = await ethers.getSigners();
+
+    // Install the mock router at the constant ROUTER address
+    const routerImpl = await (await ethers.getContractFactory("MockZRouter"))
+      .connect(user)
+      .deploy();
+    await routerImpl.deployed();
+    await setCode(ROUTER, await ethers.provider.getCode(routerImpl.address));
+
+    const ghst = await (await ethers.getContractFactory("ERC20Generic"))
+      .connect(user)
+      .deploy();
+    await ghst.deployed();
+
+    // Fund the router so swaps can succeed if reached
+    await ghst.mint(ethers.utils.parseEther("1000"), ROUTER);
+
+    const harness = await (
+      await ethers.getContractFactory("TokenSwapHarness")
+    )
+      .connect(user)
+      .deploy();
+    await harness.deployed();
+    await harness.setGHST(ghst.address);
+
+    const tokenIn = await (
+      await ethers.getContractFactory("ReturnTrueNoopERC20")
+    )
+      .connect(user)
+      .deploy();
+    await tokenIn.deployed();
+
+    const swapAmount = ethers.utils.parseEther("10");
+    const minOut = ethers.utils.parseEther("1");
+
+    // Pre-load the harness with tokenIn (simulates contract-held balance)
+    await tokenIn.mint(harness.address, swapAmount);
+    // Ensure user has balance + approval so transferFrom is called, but configured to be a NOOP.
+    await tokenIn.mint(user.address, swapAmount);
+    await tokenIn.setNoopFrom(user.address);
+    await tokenIn.approve(harness.address, swapAmount);
+
+    const deadline = (await chainNowTs()) + 3600;
+
+    await expect(
+      harness.swapForGHST(tokenIn.address, swapAmount, minOut, deadline, user.address)
+    ).to.be.revertedWith("LibTokenSwap: Token transfer failed");
+  });
+
+  it("swaps successfully when transferFrom moves tokens", async function () {
+    this.timeout(120000);
+
+    const [user] = await ethers.getSigners();
+
+    const routerImpl = await (await ethers.getContractFactory("MockZRouter"))
+      .connect(user)
+      .deploy();
+    await routerImpl.deployed();
+    await setCode(ROUTER, await ethers.provider.getCode(routerImpl.address));
+
+    const ghst = await (await ethers.getContractFactory("ERC20Generic"))
+      .connect(user)
+      .deploy();
+    await ghst.deployed();
+    await ghst.mint(ethers.utils.parseEther("1000"), ROUTER);
+
+    const harness = await (
+      await ethers.getContractFactory("TokenSwapHarness")
+    )
+      .connect(user)
+      .deploy();
+    await harness.deployed();
+    await harness.setGHST(ghst.address);
+
+    const tokenIn = await (
+      await ethers.getContractFactory("ReturnTrueNoopERC20")
+    )
+      .connect(user)
+      .deploy();
+    await tokenIn.deployed();
+
+    const swapAmount = ethers.utils.parseEther("10");
+    const minOut = ethers.utils.parseEther("3");
+    await tokenIn.mint(user.address, swapAmount);
+    await tokenIn.approve(harness.address, swapAmount);
+
+    const deadline = (await chainNowTs()) + 3600;
+
+    const ghstBefore = await ghst.balanceOf(user.address);
+    const out = await harness.callStatic.swapForGHST(tokenIn.address, swapAmount, minOut, deadline, user.address);
+    const tx = await harness.swapForGHST(tokenIn.address, swapAmount, minOut, deadline, user.address);
+    await tx.wait();
+    const ghstAfter = await ghst.balanceOf(user.address);
+
+    expect(out).to.eq(minOut);
+    expect(ghstAfter.sub(ghstBefore)).to.eq(minOut);
+  });
+});


### PR DESCRIPTION
Fixes a security bug in LibTokenSwap (PR #34 swap flows):
- Previously, _handleTokenTransfer only checked balanceOf(this) >= swapAmount and ignored ERC20 return values. If the diamond held a prior token balance, a token could return success without transferring and the swap would consume contract-held tokens.
- Now we require transferFrom success and verify the balance *delta* equals swapAmount.
- Also uses safe low-level calls for transfer/transferFrom/approve.

Includes Hardhat Base fork hardforkHistory config needed to execute forked calls.

Test:
- npx hardhat test test/security/libTokenSwap.safeTransfer.ts