### PR TITLE
LibTokenSwap: clear router allowance after swaps

### DIFF
--- a/contracts/libraries/LibTokenSwap.sol
+++ b/contracts/libraries/LibTokenSwap.sol
@@ -87,6 +87,9 @@ library LibTokenSwap {
             amountOut = _executeSwap(tokenIn, swapAmount, minGhstOut, deadline, recipient, s.GHST);
         }
 
+        // Clear any leftover allowance to reduce risk if the router doesn't spend the full approved amount.
+        _resetRouterAllowance(tokenIn);
+
         emit TokenSwapped(tokenIn, s.GHST, swapAmount, amountOut, recipient);
     }
 
@@ -105,6 +108,15 @@ library LibTokenSwap {
                 }
                 erc20.approve(ROUTER, swapAmount);
             }
+        }
+    }
+
+    function _resetRouterAllowance(address tokenIn) private {
+        if (tokenIn == address(0)) return;
+        IERC20 erc20 = IERC20(tokenIn);
+        uint256 allowance_ = erc20.allowance(address(this), ROUTER);
+        if (allowance_ > 0) {
+            erc20.approve(ROUTER, 0);
         }
     }
 

--- a/contracts/test/MockZRouter.sol
+++ b/contracts/test/MockZRouter.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/IERC20.sol";
+
+/// @notice Minimal zRouter mock used for LibTokenSwap tests.
+/// @dev Treats `amountLimit` as the output amount to send to `to`.
+contract MockZRouter {
+    function swapAero(
+        address to,
+        bool /* stable */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function swapAeroCL(
+        address to,
+        bool /* exactOut */,
+        int24 /* tickSpacing */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function swapV2(
+        address to,
+        bool /* exactOut */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function _swap(address to, address tokenIn, address tokenOut, uint256 swapAmount, uint256 amountOut) private returns (uint256, uint256) {
+        if (tokenIn == address(0)) {
+            require(msg.value == swapAmount, "MockZRouter: bad msg.value");
+        } else {
+            IERC20(tokenIn).transferFrom(msg.sender, address(this), swapAmount);
+        }
+
+        IERC20(tokenOut).transfer(to, amountOut);
+        return (swapAmount, amountOut);
+    }
+}
+

--- a/contracts/test/MockZRouterPartialSpend.sol
+++ b/contracts/test/MockZRouterPartialSpend.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/IERC20.sol";
+
+/// @notice zRouter mock that intentionally spends less than `swapAmount` to simulate routers that
+///         don't consume the full approved allowance.
+contract MockZRouterPartialSpend {
+    function swapAero(
+        address to,
+        bool /* stable */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swapPartial(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function swapAeroCL(
+        address to,
+        bool /* exactOut */,
+        int24 /* tickSpacing */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swapPartial(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function swapV2(
+        address to,
+        bool /* exactOut */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swapPartial(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function _swapPartial(address to, address tokenIn, address tokenOut, uint256 swapAmount, uint256 amountOut) private returns (uint256, uint256) {
+        uint256 spent = swapAmount / 2;
+        if (spent == 0) spent = 1;
+
+        if (tokenIn == address(0)) {
+            require(msg.value == swapAmount, "MockZRouterPartial: bad msg.value");
+        } else {
+            IERC20(tokenIn).transferFrom(msg.sender, address(this), spent);
+        }
+
+        IERC20(tokenOut).transfer(to, amountOut);
+        return (spent, amountOut);
+    }
+}
+

--- a/contracts/test/TokenSwapHarness.sol
+++ b/contracts/test/TokenSwapHarness.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../libraries/AppStorage.sol";
+import "../libraries/LibTokenSwap.sol";
+
+/// @notice Minimal harness to exercise LibTokenSwap in tests.
+/// @dev Stores AppStorage at slot 0 via Modifiers.s, matching LibTokenSwap.appStorage().
+contract TokenSwapHarness is Modifiers {
+    function setGHST(address ghst) external {
+        s.GHST = ghst;
+    }
+
+    function swapForGHST(address tokenIn, uint256 swapAmount, uint256 minGhstOut, uint256 deadline, address recipient) external payable returns (uint256) {
+        return LibTokenSwap.swapForGHST(tokenIn, swapAmount, minGhstOut, deadline, recipient);
+    }
+}
+

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,6 +33,16 @@ module.exports = {
   networks: {
     hardhat: {
       chainId: 8453,
+      // Base uses Cancun-era EVM rules. Hardhat needs a hardfork activation history for non-mainnet
+      // chainIds when executing against forked historical blocks.
+      hardfork: "cancun",
+      chains: {
+        8453: {
+          hardforkHistory: {
+            cancun: 0,
+          },
+        },
+      },
       forking: {
         url: process.env.BASE_RPC_URL,
       },

--- a/test/security/libTokenSwap.resetAllowance.ts
+++ b/test/security/libTokenSwap.resetAllowance.ts
@@ -1,0 +1,71 @@
+import { expect } from "chai";
+import { ethers, network } from "hardhat";
+
+const ROUTER = "0x0000000000404FECAf36E6184245475eE1254835";
+
+async function setCode(address: string, code: string) {
+  await network.provider.send("hardhat_setCode", [address, code]);
+}
+
+async function chainNowTs(): Promise<number> {
+  const block = await ethers.provider.getBlock("latest");
+  return block.timestamp;
+}
+
+describe("LibTokenSwap: reset router allowance", function () {
+  it("clears leftover allowance after swap", async function () {
+    this.timeout(120000);
+
+    const [user] = await ethers.getSigners();
+
+    const routerImpl = await (
+      await ethers.getContractFactory("MockZRouterPartialSpend")
+    )
+      .connect(user)
+      .deploy();
+    await routerImpl.deployed();
+    await setCode(ROUTER, await ethers.provider.getCode(routerImpl.address));
+
+    const ghst = await (await ethers.getContractFactory("ERC20Generic"))
+      .connect(user)
+      .deploy();
+    await ghst.deployed();
+    await ghst.mint(ethers.utils.parseEther("1000"), ROUTER);
+
+    const harness = await (
+      await ethers.getContractFactory("TokenSwapHarness")
+    )
+      .connect(user)
+      .deploy();
+    await harness.deployed();
+    await harness.setGHST(ghst.address);
+
+    const tokenIn = await (await ethers.getContractFactory("ERC20Generic"))
+      .connect(user)
+      .deploy();
+    await tokenIn.deployed();
+
+    const swapAmount = ethers.utils.parseEther("10");
+    const minOut = ethers.utils.parseEther("1");
+    await tokenIn.mint(swapAmount, user.address);
+    await tokenIn.approve(harness.address, swapAmount);
+
+    const deadline = (await chainNowTs()) + 3600;
+
+    // sanity: no allowance before
+    expect(await tokenIn.allowance(harness.address, ROUTER)).to.eq(0);
+
+    const tx = await harness.swapForGHST(
+      tokenIn.address,
+      swapAmount,
+      minOut,
+      deadline,
+      user.address
+    );
+    await tx.wait();
+
+    // without the fix, our partial-spend router would leave leftover allowance > 0
+    expect(await tokenIn.allowance(harness.address, ROUTER)).to.eq(0);
+  });
+});
+


### PR DESCRIPTION
Security hardening for PR #34 swap flows:
- After swapping, clear any leftover ERC20 allowance to ROUTER. This reduces blast radius if a router spends less than the approved amount (or if a prior allowance remains > swapAmount).

Includes Hardhat Base fork hardforkHistory config needed to execute forked calls.

Test:
- npx hardhat test test/security/libTokenSwap.resetAllowance.ts