### PR TITLE
Reentrancy hardening: lock auction during swap paths

### DIFF
--- a/contracts/facets/GBMFacet.sol
+++ b/contracts/facets/GBMFacet.sol
@@ -73,11 +73,18 @@ contract GBMFacet is IGBM, Modifiers {
 
         require(ctx.minGhstOut >= ctx.bidAmount, "GBM: minGhstOut must cover total bid amount");
 
+        // Lock the auction to prevent re-entrancy into buyNow/bid paths while we call into
+        // arbitrary ERC20 token contracts + external routers.
+        a.biddingAllowed = false;
+
         //execute swap
         uint256 ghstReceived = LibTokenSwap.swapForGHST(ctx.tokenIn, ctx.swapAmount, ctx.minGhstOut, ctx.swapDeadline, address(this));
 
         //make sure we received enough ghst
         require(ghstReceived >= ctx.bidAmount, "GBM: Insufficient ghst received");
+
+        // Unlock after external calls complete
+        a.biddingAllowed = true;
 
         _settleBid(ctx.auctionID, ctx.bidAmount, a);
 
@@ -115,12 +122,12 @@ contract GBMFacet is IGBM, Modifiers {
         uint256 duePay = a.dueIncentives;
         address previousHighestBidder = a.highestBidder;
 
+        // Prevent re-entrancy during external calls (token transfer/approve + router swap)
+        a.claimed = true;
+
         // perform swap
         uint256 ghstReceived = LibTokenSwap.swapForGHST(ctx.tokenIn, ctx.swapAmount, ctx.minGhstOut, ctx.swapDeadline, address(this));
         require(ghstReceived >= ae1bnp, "GBM: Insufficient ghst received");
-
-        // Prevent re-entrancy during state change
-        a.claimed = true;
 
         // Refund the highest bidder if any
         if (previousHighestBid > 0) {

--- a/contracts/test/GBMReentrancySetupFacet.sol
+++ b/contracts/test/GBMReentrancySetupFacet.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../libraries/AppStorage.sol";
+import "../libraries/LibDiamond.sol";
+
+/// @notice Small test-only facet for configuring AppStorage on a local diamond deployment.
+/// @dev This is used by security regression tests and is not intended for production upgrades.
+contract GBMReentrancySetupFacet {
+    AppStorage internal s;
+
+    modifier onlyOwner() {
+        LibDiamond.enforceIsContractOwner();
+        _;
+    }
+
+    function harnessSetGHST(address ghst) external onlyOwner {
+        s.GHST = ghst;
+    }
+
+    function harnessSetBackendPubKey(bytes calldata pubKey) external onlyOwner {
+        s.backendPubKey = pubKey;
+    }
+
+    function harnessSetFeeRecipients(address pixelcraft, address dao, address gbm, address rarityFarming) external onlyOwner {
+        s.pixelcraft = pixelcraft;
+        s.DAO = dao;
+        s.GBMAddress = gbm;
+        s.rarityFarming = rarityFarming;
+    }
+
+    function harnessSetBuyItNowInvalidationThreshold(uint256 threshold) external onlyOwner {
+        s.buyItNowInvalidationThreshold = threshold;
+    }
+
+    function harnessSetContractBiddingAllowed(address tokenContract, bool allowed) external onlyOwner {
+        s.contractBiddingAllowed[tokenContract] = allowed;
+    }
+
+    function harnessInitAuction(
+        uint256 auctionId,
+        address owner,
+        address tokenContract,
+        bytes4 tokenKind,
+        uint256 tokenId,
+        uint56 tokenAmount,
+        uint80 startTime,
+        uint80 endTime,
+        uint96 buyItNowPrice
+    ) external onlyOwner {
+        Auction storage a = s.auctions[auctionId];
+        a.owner = owner;
+        a.tokenContract = tokenContract;
+        a.info.tokenKind = tokenKind;
+        a.info.tokenID = tokenId;
+        a.info.tokenAmount = tokenAmount;
+        a.info.startTime = startTime;
+        a.info.endTime = endTime;
+
+        a.buyItNowPrice = buyItNowPrice;
+        a.startingBid = 0;
+
+        a.highestBid = 0;
+        a.highestBidder = address(0);
+        a.auctionDebt = 0;
+        a.dueIncentives = 0;
+        a.biddingAllowed = true;
+        a.claimed = false;
+
+        // Minimal presets to keep incentive math safe.
+        a.presets.bidDecimals = 1;
+        a.presets.stepMin = 0;
+        a.presets.incMin = 0;
+        a.presets.incMax = 0;
+        a.presets.bidMultiplier = 0;
+    }
+
+    function harnessGetAuctionClaimed(uint256 auctionId) external view returns (bool) {
+        return s.auctions[auctionId].claimed;
+    }
+
+    function harnessGetAuctionBiddingAllowed(uint256 auctionId) external view returns (bool) {
+        return s.auctions[auctionId].biddingAllowed;
+    }
+}
+

--- a/contracts/test/MockZRouter.sol
+++ b/contracts/test/MockZRouter.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/IERC20.sol";
+
+/// @notice Minimal zRouter mock used for LibTokenSwap/GBM swap tests.
+/// @dev Treats `amountLimit` as the output amount to send to `to`.
+contract MockZRouter {
+    function swapAero(
+        address to,
+        bool /* stable */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function swapAeroCL(
+        address to,
+        bool /* exactOut */,
+        int24 /* tickSpacing */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function swapV2(
+        address to,
+        bool /* exactOut */,
+        address tokenIn,
+        address tokenOut,
+        uint256 swapAmount,
+        uint256 amountLimit,
+        uint256 /* deadline */
+    ) external payable returns (uint256 amountIn, uint256 amountOut) {
+        return _swap(to, tokenIn, tokenOut, swapAmount, amountLimit);
+    }
+
+    function _swap(address to, address tokenIn, address tokenOut, uint256 swapAmount, uint256 amountOut) private returns (uint256, uint256) {
+        if (tokenIn == address(0)) {
+            require(msg.value == swapAmount, "MockZRouter: bad msg.value");
+        } else {
+            IERC20(tokenIn).transferFrom(msg.sender, address(this), swapAmount);
+        }
+
+        IERC20(tokenOut).transfer(to, amountOut);
+        return (swapAmount, amountOut);
+    }
+}
+

--- a/contracts/test/ReentrantBuyNowERC20.sol
+++ b/contracts/test/ReentrantBuyNowERC20.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/IERC20.sol";
+import "../interfaces/IERC721TokenReceiver.sol";
+
+/// @notice ERC20 that attempts to re-enter GBMFacet.buyNow() during transferFrom.
+/// @dev Used to test swapAndCommitBid reentrancy hardening.
+contract ReentrantBuyNowERC20 is IERC20, IERC721TokenReceiver {
+    string public name = "ReentrantBuyNowERC20";
+    string public symbol = "RBN";
+    uint8 public decimals = 18;
+
+    uint256 public override totalSupply;
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) private _allowance;
+
+    address public gbm;
+    uint256 public auctionId;
+    address public triggerFrom;
+
+    bool public attemptedBuyNow;
+    bool public buyNowCallOk;
+
+    function configure(address _gbm, uint256 _auctionId, address _triggerFrom) external {
+        gbm = _gbm;
+        auctionId = _auctionId;
+        triggerFrom = _triggerFrom;
+    }
+
+    function approveGhst(address ghst, address spender, uint256 amount) external {
+        IERC20(ghst).approve(spender, amount);
+    }
+
+    function allowance(address owner, address spender) external view override returns (uint256) {
+        return _allowance[owner][spender];
+    }
+
+    function approve(address spender, uint256 value) external override returns (bool) {
+        _allowance[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external override returns (bool) {
+        require(balanceOf[msg.sender] >= value, "RBN: insufficient");
+        balanceOf[msg.sender] -= value;
+        balanceOf[to] += value;
+        emit Transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external override returns (bool) {
+        require(balanceOf[from] >= value, "RBN: insufficient");
+
+        if (msg.sender != from) {
+            uint256 allowed = _allowance[from][msg.sender];
+            require(allowed >= value, "RBN: allowance");
+            _allowance[from][msg.sender] = allowed - value;
+        }
+
+        // Attempt reentrancy only on the initial GBMFacet -> token transferFrom call.
+        if (!attemptedBuyNow && msg.sender == gbm && from == triggerFrom && to == gbm) {
+            attemptedBuyNow = true;
+            (buyNowCallOk, ) = gbm.call(abi.encodeWithSignature("buyNow(uint256)", auctionId));
+        }
+
+        balanceOf[from] -= value;
+        balanceOf[to] += value;
+        emit Transfer(from, to, value);
+        return true;
+    }
+
+    function mint(address to, uint256 value) external {
+        balanceOf[to] += value;
+        totalSupply += value;
+        emit Transfer(address(0), to, value);
+    }
+
+    function onERC721Received(
+        address /* _operator */,
+        address /* _from */,
+        uint256 /* _tokenId */,
+        bytes calldata /* _data */
+    ) external pure override returns (bytes4) {
+        return bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"));
+    }
+}
+

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,6 +33,16 @@ module.exports = {
   networks: {
     hardhat: {
       chainId: 8453,
+      // Base uses Cancun-era EVM rules. Hardhat needs a hardfork activation history for non-mainnet
+      // chainIds when executing against forked historical blocks.
+      hardfork: "cancun",
+      chains: {
+        8453: {
+          hardforkHistory: {
+            cancun: 0,
+          },
+        },
+      },
       forking: {
         url: process.env.BASE_RPC_URL,
       },

--- a/test/security/gbmFacet.swapAndCommitBid.reentrancy.ts
+++ b/test/security/gbmFacet.swapAndCommitBid.reentrancy.ts
@@ -1,0 +1,202 @@
+import { expect } from "chai";
+import { ethers, network } from "hardhat";
+import { Wallet } from "ethers";
+
+const ROUTER = "0x0000000000404FECAf36E6184245475eE1254835";
+const ERC721_KIND = "0x73ad2146";
+const FacetCutAction = { Add: 0, Replace: 1, Remove: 2 };
+
+async function setCode(address: string, code: string) {
+  await network.provider.send("hardhat_setCode", [address, code]);
+}
+
+async function chainNowTs(): Promise<number> {
+  const block = await ethers.provider.getBlock("latest");
+  return block.timestamp;
+}
+
+function getSelectors(contract: any): string[] {
+  const signatures = Object.keys(contract.interface.functions);
+  return signatures
+    .filter((sig) => sig !== "init(bytes)")
+    .map((sig) => contract.interface.getSighash(sig));
+}
+
+describe("GBMFacet: swapAndCommitBid reentrancy hardening", function () {
+  it("prevents tokenIn reentering buyNow during swapAndCommitBid", async function () {
+    this.timeout(180000);
+
+    const [seller, bidder] = await ethers.getSigners();
+
+    // Deploy a minimal diamond with GBMFacet + a small setup facet for AppStorage configuration.
+    const diamondCutFacet = await (
+      await ethers.getContractFactory("DiamondCutFacet")
+    )
+      .connect(bidder)
+      .deploy();
+    await diamondCutFacet.deployed();
+
+    const diamond = await (await ethers.getContractFactory("GBMDiamond"))
+      .connect(bidder)
+      .deploy(bidder.address, diamondCutFacet.address, 3600, 3600);
+    await diamond.deployed();
+
+    const gbmFacetImpl = await (await ethers.getContractFactory("GBMFacet"))
+      .connect(bidder)
+      .deploy();
+    await gbmFacetImpl.deployed();
+
+    const setupFacetImpl = await (
+      await ethers.getContractFactory("GBMReentrancySetupFacet")
+    )
+      .connect(bidder)
+      .deploy();
+    await setupFacetImpl.deployed();
+
+    const cut = [
+      {
+        facetAddress: gbmFacetImpl.address,
+        action: FacetCutAction.Add,
+        functionSelectors: getSelectors(gbmFacetImpl),
+      },
+      {
+        facetAddress: setupFacetImpl.address,
+        action: FacetCutAction.Add,
+        functionSelectors: getSelectors(setupFacetImpl),
+      },
+    ];
+
+    const diamondCut = (await ethers.getContractAt(
+      "IDiamondCut",
+      diamond.address
+    )) as any;
+
+    const cutTx = await diamondCut
+      .connect(bidder)
+      .diamondCut(cut, ethers.constants.AddressZero, "0x");
+    await cutTx.wait();
+
+    const gbm = await ethers.getContractAt("GBMFacet", diamond.address);
+    const setup = await ethers.getContractAt(
+      "GBMReentrancySetupFacet",
+      diamond.address
+    );
+
+    // Install mock router at the constant ROUTER address
+    const routerImpl = await (await ethers.getContractFactory("MockZRouter"))
+      .connect(bidder)
+      .deploy();
+    await routerImpl.deployed();
+    await setCode(ROUTER, await ethers.provider.getCode(routerImpl.address));
+
+    // Deploy GHST + fund router
+    const ghst = await (await ethers.getContractFactory("ERC20Generic"))
+      .connect(bidder)
+      .deploy();
+    await ghst.deployed();
+    await ghst.mint(ethers.utils.parseEther("1000000"), ROUTER);
+
+    // Configure AppStorage via setup facet
+    await setup.connect(bidder).harnessSetGHST(ghst.address);
+    await setup.connect(bidder).harnessSetFeeRecipients(
+      bidder.address,
+      bidder.address,
+      bidder.address,
+      bidder.address
+    );
+    await setup.connect(bidder).harnessSetBuyItNowInvalidationThreshold(90);
+
+    // Deploy ERC721 + move token into GBM contract
+    const nft = await (await ethers.getContractFactory("ERC721Generic"))
+      .connect(seller)
+      .deploy();
+    await nft.deployed();
+    await nft.connect(seller)["mint(uint256)"](1);
+    const tokenId = 1;
+    await nft
+      .connect(seller)
+      .transferFrom(seller.address, diamond.address, tokenId);
+
+    // Init an auction in storage
+    const auctionId = 0;
+    const now = await chainNowTs();
+    const buyNowPrice = ethers.utils.parseEther("10");
+    await setup.connect(bidder).harnessInitAuction(
+      auctionId,
+      seller.address,
+      nft.address,
+      ERC721_KIND,
+      tokenId,
+      1,
+      now - 1,
+      now + 86400,
+      buyNowPrice
+    );
+    await setup
+      .connect(bidder)
+      .harnessSetContractBiddingAllowed(nft.address, true);
+
+    // Configure backend signer + pubkey
+    const backend = Wallet.createRandom();
+    const pubKey = backend._signingKey().publicKey; // 0x04...
+    const pubKeyBytes = ethers.utils.arrayify(pubKey).slice(1);
+    await setup.connect(bidder).harnessSetBackendPubKey(pubKeyBytes);
+
+    // Deploy reentrant tokenIn + configure it to attempt buyNow during transferFrom
+    const tokenIn = await (
+      await ethers.getContractFactory("ReentrantBuyNowERC20")
+    )
+      .connect(bidder)
+      .deploy();
+    await tokenIn.deployed();
+    await tokenIn.configure(diamond.address, auctionId, bidder.address);
+
+    // Fund tokenIn contract with GHST to pay buyNow, and approve GBM to spend it.
+    await ghst.mint(buyNowPrice, tokenIn.address);
+    await tokenIn.approveGhst(ghst.address, diamond.address, buyNowPrice);
+
+    // Fund bidder with tokenIn + approve GBM to spend it for the swap.
+    const swapAmount = ethers.utils.parseEther("100");
+    await tokenIn.mint(bidder.address, swapAmount);
+    await tokenIn.connect(bidder).approve(diamond.address, swapAmount);
+
+    // Build a valid commitBid signature
+    const bidAmount = ethers.utils.parseEther("5");
+    const highestBid = 0;
+    const messageHash = ethers.utils.solidityKeccak256(
+      ["address", "uint256", "uint256", "uint256"],
+      [bidder.address, auctionId, bidAmount, highestBid]
+    );
+    const signature = await backend.signMessage(
+      ethers.utils.arrayify(messageHash)
+    );
+
+    const swapDeadline = (await chainNowTs()) + 3600;
+
+    const ctx = {
+      tokenIn: tokenIn.address,
+      swapAmount,
+      minGhstOut: bidAmount,
+      swapDeadline,
+      recipient: bidder.address,
+      auctionID: auctionId,
+      bidAmount,
+      highestBid,
+      tokenContract: nft.address,
+      _tokenID: tokenId,
+      _amount: 1,
+      _signature: signature,
+    };
+
+    await gbm.connect(bidder).swapAndCommitBid(ctx);
+
+    // The reentrancy attempt was made, but should fail due to the auction lock.
+    expect(await tokenIn.attemptedBuyNow()).to.eq(true);
+    expect(await tokenIn.buyNowCallOk()).to.eq(false);
+
+    // Auction should not be claimed and the NFT should remain escrowed in the GBM contract.
+    expect(await setup.harnessGetAuctionClaimed(auctionId)).to.eq(false);
+    expect(await nft.ownerOf(tokenId)).to.eq(diamond.address);
+    expect(await setup.harnessGetAuctionBiddingAllowed(auctionId)).to.eq(true);
+  });
+});


### PR DESCRIPTION
Fixes reentrancy window in swap entrypoints by locking the auction state while calling into arbitrary ERC20 + external router code.

- swapAndCommitBid: temporarily sets auction.biddingAllowed=false before swap, restores after swap
- swapAndBuyNow: sets auction.claimed=true before swap to block reentrancy

Tests:
- npx hardhat test test/security/gbmFacet.swapAndCommitBid.reentrancy.ts